### PR TITLE
Update googleads/googleads-php-lib version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "type": "library",
   "description": "Google Ads API for Laravel",
   "minimum-stability": "dev",
+  "prefer-stable": true,
   "keywords": [
     "laravel",
     "ads",
@@ -21,9 +22,9 @@
   "require": {
     "php": ">=5.5.9",
     "ext-soap": "*",
-    "illuminate/console": ">=5.1",
+    "illuminate/console": "^5.1",
     "illuminate/support": "^5.1",
-    "googleads/googleads-php-lib": "^35.0"
+    "googleads/googleads-php-lib": "^37.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Use `"prefer-stable": true,` otherwise all the dependencies will pull from their respective master branches rather than published versions.